### PR TITLE
0.14.7 Interns ignore bee nest and dead bodies, configurable on next …

### DIFF
--- a/AI/InternAI.cs
+++ b/AI/InternAI.cs
@@ -1166,13 +1166,16 @@ namespace LethalInternship.AI
                     continue;
                 }
 
+                if (IsGrabbableObjectBlackListed(gameObject))
+                {
+                    continue;
+                }
+                
                 GrabbableObject? grabbableObject = gameObject.GetComponent<GrabbableObject>();
                 if (grabbableObject == null)
                 {
                     return null;
                 }
-
-                // todo: grab "RedLocustHive(Clone)", bodies "RagdollGrabbableObject(Clone)" ?
 
                 // Object close to awareness distance ?
                 if (sqrDistanceEyeGameObject < Const.INTERN_OBJECT_AWARNESS * Const.INTERN_OBJECT_AWARNESS)
@@ -1275,6 +1278,25 @@ namespace LethalInternship.AI
                     DictJustDroppedItems.Remove(item.Key);
                 }
             }
+        }
+
+        private bool IsGrabbableObjectBlackListed(GameObject gameObjectToEvaluate)
+        {
+            // Bee nest
+            if (gameObjectToEvaluate.name.Contains("RedLocustHive"))
+            {
+                return true;
+            }
+
+            // Dead bodies
+            if (gameObjectToEvaluate.name.Contains("RagdollGrabbableObject")
+                && gameObjectToEvaluate.tag == "PhysicsProp"
+                && gameObjectToEvaluate.GetComponentInParent<DeadBodyInfo>() != null)
+            {
+                return true;
+            }
+
+            return false;
         }
 
         #region TeleportIntern RPC

--- a/Const.cs
+++ b/Const.cs
@@ -12,6 +12,7 @@ namespace LethalInternship
         public const string MOREEMOTES_GUID = "MoreEmotes";
         public const string MODELREPLACEMENT_GUID = "meow.ModelReplacementAPI";
         public const string LETHALPHONES_GUID = "LethalPhones";
+        public const string FASTERITEMDROPSHIP_GUID = "FlipMods.FasterItemDropship";
 
         public static readonly float EPSILON = 0.01f;
         public static readonly bool DISABLE_ORIGINAL_GAME_DEBUG_LOGS = true;

--- a/LethalInternship.csproj
+++ b/LethalInternship.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>LethalInternship</AssemblyName>
     <Product>LethalInternship</Product>
     <!-- Change to whatever version you're currently on. This will be used by tcli when building our Thunderstore package. -->
-    <Version>0.14.6</Version>
+    <Version>0.14.7</Version>
   </PropertyGroup>
 
   <!-- Project Properties -->
@@ -90,6 +90,9 @@
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
       <HintPath>lib\Assembly-CSharp-firstpass.dll</HintPath>
+    </Reference>
+    <Reference Include="FasterItemDropship">
+      <HintPath>lib\mods\FasterItemDropship.dll</HintPath>
     </Reference>
     <Reference Include="FuckYouMod">
       <HintPath>lib\mods\MoreEmotes1.3.3.dll</HintPath>

--- a/Managers/InternManager.cs
+++ b/Managers/InternManager.cs
@@ -93,7 +93,6 @@ namespace LethalInternship.Managers
         {
             StartOfRound instance = StartOfRound.Instance;
 
-            Plugin.LogInfo("Attempt to populate pool of interns.");
             if (instance.allPlayerObjects[3].gameObject == null)
             {
                 Plugin.LogInfo("No player objects initialized in game, aborting interns initializations.");
@@ -111,6 +110,7 @@ namespace LethalInternship.Managers
             if (instance.allPlayerScripts.Length == AllEntitiesCount)
             {
                 // the arrays have not been resize between round
+                Plugin.LogInfo("Pool of interns ok. The arrays have not been resize between round");
                 return;
             }
 
@@ -134,6 +134,8 @@ namespace LethalInternship.Managers
         /// <param name="irlPlayersCount">Number of "real" players, 4 without morecompany, for calculating resizing</param>
         private void ResizePoolOfInterns(int irlPlayersCount)
         {
+            Plugin.LogInfo($"Attempt to resize pool of interns. irlPlayersCount {irlPlayersCount}");
+
             StartOfRound instance = StartOfRound.Instance;
             Plugin.LogDebug($"instance.allPlayerObjects.Length {instance.allPlayerObjects.Length} AllEntitiesCount {AllEntitiesCount}");
 
@@ -154,6 +156,7 @@ namespace LethalInternship.Managers
         /// <param name="irlPlayersCount">Number of "real" players, 4 without morecompany, for calculating parameterization</param>
         private void PopulatePoolOfInterns(int irlPlayersCount)
         {
+            Plugin.LogDebug($"Attempt to populate pool of interns. irlPlayersCount {irlPlayersCount}");
             StartOfRound instance = StartOfRound.Instance;
             GameObject internObjectParent = instance.allPlayerObjects[3].gameObject;
 
@@ -278,7 +281,7 @@ namespace LethalInternship.Managers
                                           int indexNextIntern, int indexNextPlayerObject,
                                           Vector3 spawnPosition, float yRot, bool isOutside)
         {
-            Plugin.LogInfo($"Client receive NOR after spawned on server...");
+            Plugin.LogInfo($"Client receive RPC to spawn intern on his side...");
 
             networkObjectReferenceInternAI.TryGet(out NetworkObject networkObjectInternAI);
             InternAI internAI = networkObjectInternAI.gameObject.GetComponent<InternAI>();

--- a/Patches/EnemiesPatches/RadMechMissilePatch.cs
+++ b/Patches/EnemiesPatches/RadMechMissilePatch.cs
@@ -1,0 +1,48 @@
+﻿using HarmonyLib;
+using LethalInternship.Utils;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+
+namespace LethalInternship.Patches.EnemiesPatches
+{
+    [HarmonyPatch(typeof(RadMechMissile))]
+    internal class RadMechMissilePatch
+    {
+        [HarmonyPatch("CheckCollision")]
+        [HarmonyTranspiler]
+        static IEnumerable<CodeInstruction> CheckCollision_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            var startIndex = -1;
+            List<CodeInstruction> codes = new List<CodeInstruction>(instructions);
+
+            // ----------------------------------------------------------------------
+            for (var i = 0; i < codes.Count - 2; i++)
+            {
+                if (codes[i].ToString() == "call static GameNetworkManager GameNetworkManager::get_Instance()" // 69
+                    && codes[i + 1].ToString() == "ldfld GameNetcodeStuff.PlayerControllerB GameNetworkManager::localPlayerController"
+                    && codes[i + 2].ToString() == "call static bool UnityEngine.Object::op_Equality(UnityEngine.Object x, UnityEngine.Object y)")
+                {
+                    startIndex = i;
+                    break;
+                }
+            }
+            if (startIndex > -1)
+            {
+                codes[startIndex].opcode = OpCodes.Call;
+                codes[startIndex].operand = PatchesUtil.IsPlayerLocalOrInternOwnerLocalMethod;
+                codes[startIndex + 1].opcode = OpCodes.Nop;
+                codes[startIndex + 1].operand = null;
+                codes[startIndex + 2].opcode = OpCodes.Nop;
+                codes[startIndex + 2].operand = null;
+                startIndex = -1;
+            }
+            else
+            {
+                Plugin.LogError($"LethalInternship.Patches.EnemiesPatches.RadMechMissile.CheckCollision_Transpiler could not check if interns collide with missile.");
+            }
+
+            return codes.AsEnumerable();
+        }
+    }
+}

--- a/Patches/MapPatches/ItemDropShipPatch.cs
+++ b/Patches/MapPatches/ItemDropShipPatch.cs
@@ -1,6 +1,4 @@
-﻿using GameNetcodeStuff;
-using HarmonyLib;
-using LethalInternship.AI;
+﻿using HarmonyLib;
 using LethalInternship.Managers;
 using LethalInternship.Utils;
 using System.Collections.Generic;

--- a/Patches/ModPatches/FasterItemDropshipPatch.cs
+++ b/Patches/ModPatches/FasterItemDropshipPatch.cs
@@ -1,0 +1,60 @@
+﻿using FasterItemDropship;
+using HarmonyLib;
+using LethalInternship.Managers;
+using UnityEngine;
+
+namespace LethalInternship.Patches.ModPatches
+{
+    [HarmonyPatch(typeof(ItemDropship))]
+    internal class FasterItemDropshipPatch
+    {
+        private static float previousShipTimer = 0f;
+        private static bool previousFirstOrder = true;
+
+        [HarmonyPatch("Update")]
+        [HarmonyPrefix]
+        [HarmonyBefore(Const.FASTERITEMDROPSHIP_GUID)]
+        static void Update_PreFix(ItemDropship __instance,
+                                  Terminal ___terminalScript)
+        {
+            if (!__instance.IsServer)
+            {
+                return;
+            }
+
+            previousShipTimer = __instance.shipTimer;
+            previousFirstOrder = __instance.playersFirstOrder;
+
+            if (!__instance.deliveringOrder
+                && !StartOfRound.Instance.shipHasLanded
+                && ConfigSettings.startDeliveryBeforePlayerShipLanded.Value)
+            {
+                if (___terminalScript.orderedItemsFromTerminal.Count > 0 || ___terminalScript.orderedVehicleFromTerminal != -1 || InternManager.Instance.AreInternsScheduledToLand())
+                {
+                    __instance.shipTimer += Time.deltaTime;
+                }
+
+                if (___terminalScript.orderedItemsFromTerminal.Count > 0 || ___terminalScript.orderedVehicleFromTerminal != -1)
+                {
+                    // Cancel the update
+                    __instance.shipTimer -= Time.deltaTime;
+                }
+            }
+        }
+
+        [HarmonyPatch("Update")]
+        [HarmonyPostfix]
+        [HarmonyAfter(Const.FASTERITEMDROPSHIP_GUID)]
+        static void Update_Postfix(ItemDropship __instance,
+                                   Terminal ___terminalScript)
+        {
+            if (__instance.IsServer 
+                && !__instance.deliveringOrder 
+                && (__instance.shipTimer < previousShipTimer || (previousFirstOrder && !__instance.playersFirstOrder)) 
+                && (___terminalScript.orderedItemsFromTerminal.Count > 0 || ___terminalScript.orderedVehicleFromTerminal != -1 || InternManager.Instance.AreInternsScheduledToLand()))
+            {
+                __instance.shipTimer = 40 - ConfigSettings.dropshipDeliveryTime.Value;
+            }
+        }
+    }
+}

--- a/Patches/NpcPatches/EnemyAIPatch.cs
+++ b/Patches/NpcPatches/EnemyAIPatch.cs
@@ -169,7 +169,6 @@ namespace LethalInternship.Patches.NpcPatches
         {
             PlayerControllerB internControllerFound = null!;
 
-            __instance.mostOptimalDistance = 2000f;
             for (int i = InternManager.Instance.IndexBeginOfInterns; i < StartOfRound.Instance.allPlayerScripts.Length; i++)
             {
                 PlayerControllerB internController = StartOfRound.Instance.allPlayerScripts[i];
@@ -248,9 +247,8 @@ namespace LethalInternship.Patches.NpcPatches
         [HarmonyPostfix]
         static void TargetClosestPlayer_PostFix(EnemyAI __instance, ref bool __result, float bufferDistance, bool requireLineOfSight, float viewWidth)
         {
-            __instance.mostOptimalDistance = 2000f;
-            PlayerControllerB playerControllerB = __instance.targetPlayer;
-            __instance.targetPlayer = null;
+            PlayerControllerB playerTargetted = __instance.targetPlayer;
+            
             for (int i = InternManager.Instance.IndexBeginOfInterns; i < StartOfRound.Instance.allPlayerScripts.Length; i++)
             {
                 PlayerControllerB intern = StartOfRound.Instance.allPlayerScripts[i];
@@ -267,10 +265,10 @@ namespace LethalInternship.Patches.NpcPatches
                     }
                 }
             }
-            if (__instance.targetPlayer != null && bufferDistance > 0f && playerControllerB != null
-                && Mathf.Abs(__instance.mostOptimalDistance - Vector3.Distance(__instance.transform.position, playerControllerB.transform.position)) < bufferDistance)
+            if (__instance.targetPlayer != null && bufferDistance > 0f && playerTargetted != null
+                && Mathf.Abs(__instance.mostOptimalDistance - Vector3.Distance(__instance.transform.position, playerTargetted.transform.position)) < bufferDistance)
             {
-                __instance.targetPlayer = playerControllerB;
+                __instance.targetPlayer = playerTargetted;
             }
             __result = __instance.targetPlayer != null;
         }

--- a/Patches/NpcPatches/PlayerControllerBPatch.cs
+++ b/Patches/NpcPatches/PlayerControllerBPatch.cs
@@ -1009,6 +1009,16 @@ namespace LethalInternship.Patches.NpcPatches
             }
         }
 
+        [HarmonyPatch("IVisibleThreat.GetThreatTransform")]
+        [HarmonyPostfix]
+        static void GetThreatTransform_PostFix(PlayerControllerB __instance, ref Transform __result)
+        {
+            InternAI? internAI = InternManager.Instance.GetInternAI((int)__instance.playerClientId);
+            if (internAI != null)
+            {
+                __result = internAI.transform;
+            }
+        }
 
         #endregion
     }

--- a/Patches/ObjectsPatches/StunGrenadeItemPatch.cs
+++ b/Patches/ObjectsPatches/StunGrenadeItemPatch.cs
@@ -1,0 +1,34 @@
+﻿using GameNetcodeStuff;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace LethalInternship.Patches.ObjectsPatches
+{
+    [HarmonyPatch(typeof(StunGrenadeItem))]
+    internal class StunGrenadeItemPatch
+    {
+        [HarmonyPatch("StunExplosion")]
+        [HarmonyPostfix]
+        static void StunExplosion_PostFix(Vector3 explosionPosition, 
+                                          bool isHeldItem, 
+                                          PlayerControllerB playerHeldBy)
+        {
+            // todo StunExplosion For later
+
+            // for every intern { yada yada
+            //PlayerControllerB playerControllerB = GameNetworkManager.Instance.localPlayerController;
+            //if (GameNetworkManager.Instance.localPlayerController.isPlayerDead && GameNetworkManager.Instance.localPlayerController.spectatedPlayerScript != null)
+            //{
+            //    playerControllerB = GameNetworkManager.Instance.localPlayerController.spectatedPlayerScript;
+            //}
+
+            //if (isHeldItem && playerHeldBy == GameNetworkManager.Instance.localPlayerController)
+            //{
+            //    GameNetworkManager.Instance.localPlayerController.DamagePlayer(20, false, true, CauseOfDeath.Blast, 0, false, default(Vector3));
+            //}
+        }
+    }
+}

--- a/Thunderstore/CHANGELOG.md
+++ b/Thunderstore/CHANGELOG.md
@@ -1,15 +1,23 @@
 # Changelog
 
+## 0.14.7 [Alpha] - 2024-08-09
+### Changed
+- Interns ignore bee nest and dead bodies, configurable on next update.
+### Fixed
+- Attempt to fix compatibility error type of "[Error  : Unity Log] NetworkPrefab ('prefabName') has a duplicate GlobalObjectIdHash source entry value of: 'value'!", thanks @Adrian on discord.
+- Fix for Jester and ForestGiant (can not reproduce for ForestGiant) not targetting player, thanks @Adrian on discord. thanks @doubletime32 on Github, issue 17 ([#17](https://github.com/Szumi57/LethalInternship/issues/17))
+- Fix for compatibility with mod FasterItemDropship, thanks me.
+- Fix for old bird missiles pushing interns, also errors between old bird and interns (CheckSightForThreat stuff), thanks @Autumnis the Everchanging on Discord
+
 ## 0.14.6 [Alpha] - 2024-08-05
+### Changed
+- Interns are faster on ladders.
+- Interns can use ladders even with a two handed item in hands.
 ### Hotfix
 - Fix compatibility with LethalPhones, thanks @crump_laude on discord. Fixed but not functionnal for interns, no change (I hope) for the players. 
 - Fix Masked unable to grab interns, thanks @Autumnis the Everchanging on discord.
 - Fix bracken unable to grab interns, thanks @random_axolotl on discord.
 - Fix terminal commands from base game pages, able to type 'c' to confirm, issue 12 ([#12](https://github.com/Szumi57/LethalInternship/issues/12))
-
-### Changed
-- Interns are faster on ladders.
-- Interns can use ladders even with a two handed item in hands.
 
 ## 0.14.5 [Alpha] - 2024-08-03
 ### Hotfix

--- a/Thunderstore/thunderstore.toml
+++ b/Thunderstore/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 repository = "https://thunderstore.io"
 
 [package]
-description = "Recruit interns, take them with you, grab items, make company happy, they may or may not help but what can you do ? It's their first experience."
+description = "[No V60 yet] Recruit interns, take them with you, grab items, make company happy, they may or may not help but what can you do ? It's their first experience."
 websiteUrl = "https://github.com/Szumi57/LethalInternship"
 containsNsfwContent = false
 [package.dependencies]


### PR DESCRIPTION
…update.

- Attempt to fix compatibility error type of "[Error  : Unity Log] NetworkPrefab ('prefabName') has a duplicate GlobalObjectIdHash source entry value of: 'value'!"
- Fix for Jester and ForestGiant (can not reproduce for ForestGiant) not targetting player
- Fix for compatibility with mod FasterItemDropship
- Fix for old bird missiles pushing interns, also errors between old bird and interns (CheckSightForThreat stuff)